### PR TITLE
Display help when no command given

### DIFF
--- a/lib/evm/cli.rb
+++ b/lib/evm/cli.rb
@@ -11,11 +11,11 @@ module Evm
         options[:use] = !!argv.delete('--use')
       end
 
-      if argv.include?('--help') || argv.include?('-h')
+      command, argument = argv
+
+      if argv.include?('--help') || argv.include?('-h') || command.nil?
         Evm.print_usage_and_exit
       end
-
-      command, argument = argv
 
       begin
         const = Evm::Command.const_get(command.capitalize)

--- a/spec/evm/cli_spec.rb
+++ b/spec/evm/cli_spec.rb
@@ -68,6 +68,14 @@ describe Evm::Cli do
 
   end
 
+  it 'should print usage and die if no command given' do
+    Evm.should_receive(:print_usage_and_exit)
+
+    expect {
+      Evm::Cli.parse([])
+    }.to raise_error(SystemExit)
+  end
+
   it 'should print message and exit if command not found' do
     STDERR.should_receive(:puts).with('No such command: bar')
 


### PR DESCRIPTION
[`brew`](http://brew.sh/) or `gem` display help when no command given. This commit make `evm` behave in the same way.
