### PR TITLE
Fixing install when $USER isn't a valid group name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ No matter what installation approach you choose, create
 
 ```sh
 $ sudo mkdir /usr/local/evm
-$ sudo chown $USER:$USER /usr/local/evm
+$ sudo chown $USER: /usr/local/evm
 ```
 
 ### Automatic


### PR DESCRIPTION
By using a trailing colon, chown picks the appropriate group for the
current user.
