### PR TITLE
Create symlink for emacsclient in use! method.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /evm-*.gem
-/bin/emacs
-/bin/evm-emacs
-/bin/emacsclient
-/bin/evm-emacsclient
+/bin/*
+!bin/evm

--- a/lib/evm.rb
+++ b/lib/evm.rb
@@ -3,10 +3,9 @@ require 'fileutils'
 module Evm
   ROOT_PATH = File.expand_path('..', File.dirname(__FILE__))
   LOCAL_PATH = File.join('/', 'usr', 'local', 'evm')
-  EMACS_PATH = File.join(ROOT_PATH, 'bin', 'emacs')
-  EVM_EMACS_PATH = File.join(ROOT_PATH, 'bin', 'evm-emacs')
-  EMACSCLIENT_PATH = File.join(ROOT_PATH, 'bin', 'emacs')
-  EVM_EMACSCLIENT_PATH = File.join(ROOT_PATH, 'bin', 'evm-emacs')
+  EMACS_BIN_PATH = File.join(ROOT_PATH, 'bin')
+  EMACS_PATH = File.join(EMACS_BIN_PATH, 'emacs')
+  EVM_EMACS_PATH = File.join(EMACS_BIN_PATH, 'evm-emacs')
 
   def self.abort(*args)
     STDERR.puts args.join(' ')


### PR DESCRIPTION
I started to use evm in linux and the emacsclient binary is not present. The PR solves this. 

@rejeep, I'm not totally convinced with this approach, If you have a better idea I will be happy to modify this PR.
I'll add specs after receiving your feedback. Thanks!

ps: I'm not 100% sure, but emacsclient in mac osx is not working well, right? 
