### PR TITLE
Don't compile with GIF support.

### DIFF
--- a/recipes/emacs-23.4.rb
+++ b/recipes/emacs-23.4.rb
@@ -12,6 +12,7 @@ recipe 'emacs-23.4' do
 
     option '--prefix', installation_path
     option "--with-crt-dir=#{crt_dir}"
+    option '--without-gif'
   end
 
   install do

--- a/recipes/emacs-24.1.rb
+++ b/recipes/emacs-24.1.rb
@@ -9,6 +9,7 @@ recipe 'emacs-24.1' do
 
   linux do
     option '--prefix', installation_path
+    option '--without-gif'
   end
 
   install do

--- a/recipes/emacs-24.2.rb
+++ b/recipes/emacs-24.2.rb
@@ -9,6 +9,7 @@ recipe 'emacs-24.2' do
 
   linux do
     option '--prefix', installation_path
+    option '--without-gif'
   end
 
   install do

--- a/recipes/emacs-24.3.rb
+++ b/recipes/emacs-24.3.rb
@@ -9,6 +9,7 @@ recipe 'emacs-24.3' do
 
   linux do
     option '--prefix', installation_path
+    option '--without-gif'
   end
 
   install do

--- a/recipes/emacs-git-snapshot.rb
+++ b/recipes/emacs-git-snapshot.rb
@@ -9,6 +9,7 @@ recipe 'emacs-git-snapshot' do
 
   linux do
     option '--prefix', installation_path
+    option '--without-gif'
   end
 
   install do


### PR DESCRIPTION
Emacs source depends on libgif, which is an abandoned project[1]. Some
distros, such as Arch Linux patch Emacs to support giflib[2]. For EVM, I
think it's sufficient to compile without GIF support.

[1] https://bugs.archlinux.org/task/8927?project=1&pagenum=11
[2] https://projects.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/emacs&id=b7683f99af92c2387e6a01d7e386453223e0f4e7
