### PR TITLE
Add version flag to CLI

### DIFF
--- a/lib/evm.rb
+++ b/lib/evm.rb
@@ -30,8 +30,14 @@ OPTIONS:
  --force                    Force install even when already installed
  --use                      Select as current package after installing
  --skip                     Ignore if already installed
+ --version, -v              Display the version
  --help, -h                 Display this help message
     EOS
+  end
+
+  def self.print_version_and_exit
+    STDOUT.puts "0.6.0"
+    exit 0
   end
 end
 

--- a/lib/evm/cli.rb
+++ b/lib/evm/cli.rb
@@ -21,6 +21,10 @@ module Evm
         Evm.print_usage_and_exit
       end
 
+      if argv.include?('--version') || argv.include?('-v')
+        Evm.print_version_and_exit
+      end
+
       begin
         const = Evm::Command.const_get(command.capitalize)
       rescue NameError => exception


### PR DESCRIPTION
Add version flag to CLI

This should be augmented to retrieve the version information from the gemspec.

    Gem::Specification::load("evm.gemspec").version

works, but must be done at project root.  There has to be a better way.