### PR TITLE
Add error messages when we can't write to /usr/local/evm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ source 'https://rubygems.org'
 group :test do
   gem 'rspec'
   gem 'webmock'
+  gem 'fakefs'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
     crack (0.4.1)
       safe_yaml (~> 0.9.0)
     diff-lcs (1.2.5)
+    fakefs (0.6.7)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -22,5 +23,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  fakefs
   rspec
   webmock

--- a/lib/evm/cli.rb
+++ b/lib/evm/cli.rb
@@ -21,6 +21,14 @@ module Evm
         Evm.print_usage_and_exit
       end
 
+      unless File.directory?('/usr/local/evm')
+        Evm.abort "Directory '/usr/local/evm' does not exist. Did you forget to run 'sudo mkdir /usr/local/evm'?"
+      end
+
+      unless File.stat('/usr/local/evm').writable?
+        Evm.abort "You can't write to '/usr/local/evm'. Did you forget to run 'sudo chown $USER: /usr/local/evm'?"
+      end
+
       begin
         const = Evm::Command.const_get(command.capitalize)
       rescue NameError => exception

--- a/spec/evm/cli_spec.rb
+++ b/spec/evm/cli_spec.rb
@@ -90,3 +90,38 @@ describe Evm::Cli do
     }.to raise_error(SystemExit)
   end
 end
+
+require 'fakefs/spec_helpers'
+
+describe "EVM::Cli file system operations" do
+  # These tests go in a separate describe block so that FakeFS doesn't
+  # affect other tests.
+  include FakeFS::SpecHelpers
+
+  before do
+    @foo = double('Foo')
+
+    stub_const('Evm::Command::Foo', @foo)
+  end
+
+  it 'should give an error if install directory does not exist' do
+    STDERR.should_receive(:puts).with(/does not exist/)
+
+    expect {
+      Evm::Cli.parse(['foo'])
+    }.to raise_error(SystemExit)
+  end
+
+  # Disabled: Waiting for fix to bug #308 in fakefs (writable? is not
+  # mocked correctly).
+  xit 'should give an error if install directory is not writable' do
+
+    FileUtils.mkdir_p '/usr/local/evm', mode: 0000
+    STDERR.should_receive(:puts).with(/can't write to/)
+
+    expect {
+      Evm::Cli.parse(['foo'])
+    }.to raise_error(SystemExit)
+  end
+
+end


### PR DESCRIPTION
Check for existence and writability of the directory, and give helpful
error messages if the checks fail.

Even though the readme says to use `chown` on the directory I think the
correct thing to *check* is writablity rather than ownership (since
advanced users could have the directory world-writable, or other strange
things, right?).

This is my first ever attempt at writing Ruby so read with caution and sorry for any stupid mistakes :)

Related to comments in #39.