### PR TITLE
Change cp command options

### DIFF
--- a/lib/evm/builder.rb
+++ b/lib/evm/builder.rb
@@ -85,7 +85,7 @@ module Evm
       end
 
       def copy(from, to)
-        FileUtils.cp_r(from, to, preserve: true)
+        run_command "cp -a #{from} #{to}"
       end
 
       private

--- a/spec/evm/builder_spec.rb
+++ b/spec/evm/builder_spec.rb
@@ -201,9 +201,8 @@ describe Evm::Builder do
     end
 
     describe '#copy' do
-      it 'should copy recursively' do
-        FileUtils.should_receive(:cp_r).with('from', 'to', preserve: true)
-
+      it 'copies all files recursively and preserves file attributes' do
+        @dsl.should_receive(:run_command).with('cp -a from to')
         @dsl.copy 'from', 'to'
       end
     end


### PR DESCRIPTION
For some files (links I believe), there was an issue with the previous cp command raising this error:

    No such file or directory - /tmp/emacs-24.3-travis/bin/emacs (Errno::ENOENT)

I'm not sure why this is as I never was able to reproduce it in any other environment than Travis, but the new cp options seems to have solved the issue.

@tonini Would you mind trying this branch out and see if it solves your issue?