### PR TITLE
Add support for Emacs-25.0.94 pre-test

### DIFF
--- a/lib/evm/builder.rb
+++ b/lib/evm/builder.rb
@@ -23,16 +23,12 @@ module Evm
         end
       end
 
+      def tar_xz(url)
+        tar_packaged(url, 'xz')
+      end
+
       def tar_gz(url)
-        tar_file_path = File.join(builds_path, @name + '.tar.gz')
-
-        remote_file = Evm::RemoteFile.new(url)
-        remote_file.download(tar_file_path)
-
-        FileUtils.mkdir(build_path)
-
-        tar_file = Evm::TarFile.new(tar_file_path)
-        tar_file.extract(builds_path, @name)
+        tar_packaged(url, 'gz')
       end
 
       def osx(&block)
@@ -89,6 +85,18 @@ module Evm
       end
 
       private
+
+      def tar_packaged(url,extension)
+        tar_file_path = File.join(builds_path, @name + '.tar.' + extension)
+
+        remote_file = Evm::RemoteFile.new(url)
+        remote_file.download(tar_file_path)
+
+        FileUtils.mkdir(build_path)
+
+        tar_file = Evm::TarFile.new(tar_file_path)
+        tar_file.extract(builds_path, @name)
+      end
 
       def run_command(command, *args)
         Dir.chdir(build_path) do

--- a/lib/evm/tar_file.rb
+++ b/lib/evm/tar_file.rb
@@ -6,7 +6,7 @@ module Evm
 
     def extract(extract_to, name = nil)
       args = []
-      args << '-xzf'
+      args << '-xf'
       args << @tar_file
       args << '-C'
 

--- a/recipes/emacs-25-pre-travis.rb
+++ b/recipes/emacs-25-pre-travis.rb
@@ -1,0 +1,7 @@
+recipe 'emacs-25-pre-travis' do
+  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.8.0/emacs-25-pre-travis.tar.gz'
+
+  install do
+    copy build_path, installations_path
+  end
+end

--- a/recipes/emacs-25-pre.rb
+++ b/recipes/emacs-25-pre.rb
@@ -1,0 +1,23 @@
+recipe 'emacs-25-pre' do
+  tar_xz 'http://alpha.gnu.org/gnu/emacs/pretest/emacs-25.0.94.tar.xz'
+
+  osx do
+    option '--with-ns'
+    option '--without-x'
+    option '--without-dbus'
+  end
+
+  linux do
+    option '--prefix', installation_path
+    option '--without-gif'
+  end
+
+  install do
+    configure
+    make 'install'
+
+    osx do
+      copy File.join(build_path, 'nextstep', 'Emacs.app'), installation_path
+    end
+  end
+end

--- a/spec/evm/tar_file_spec.rb
+++ b/spec/evm/tar_file_spec.rb
@@ -9,12 +9,12 @@ describe Evm::TarFile do
 
   describe '#extract' do
     it 'extracts tar file to path when no name' do
-      subject.should_receive(:tar).with('-xzf', @tar_file, '-C', '/path/to')
+      subject.should_receive(:tar).with('-xf', @tar_file, '-C', '/path/to')
       subject.extract('/path/to')
     end
 
     it 'extracts tar file to path/name when name' do
-      subject.should_receive(:tar).with('-xzf', @tar_file, '-C', '/path/to/directory', '--strip-components', '1')
+      subject.should_receive(:tar).with('-xf', @tar_file, '-C', '/path/to/directory', '--strip-components', '1')
       subject.extract('/path/to', 'directory')
     end
   end


### PR DESCRIPTION
As discussed in #69.

I've had to refactor some parts -- particularly I've removed the "z" from "tar xvfz". My tar just copes with this (and does xv files also). Don't know about the mac tar though.
