### PR TITLE
Add disuse command to restore system default

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ $ evm use emacs-24.2
 
 The Evm binary will update and use that Emacs package.
 
+### disuse
+
+To stop using an EVM binary and restore your personal or system defaults:
+
+```sh
+$ evm disuse
+```
+
 ### uninstall <name>
 
 To uninstall a version, run:

--- a/lib/evm/cli.rb
+++ b/lib/evm/cli.rb
@@ -17,6 +17,7 @@ module Evm
         opts.separator  '        bin [name]                   Show path to Emacs binary for package name'
         opts.separator  '        list                         List all available packages'
         opts.separator  '        use <name>                   Select name as current package'
+        opts.separator  '        disuse                       Stop using the current package (remove binary from path but leave installed)'
         opts.separator  '        config <var> <value>         Set the value of a configuration variable (like path)'
         opts.separator  '        help                         Display this help message'
         opts.separator  ''

--- a/lib/evm/command.rb
+++ b/lib/evm/command.rb
@@ -6,6 +6,7 @@ end
 require 'evm/command/install'
 require 'evm/command/uninstall'
 require 'evm/command/use'
+require 'evm/command/disuse'
 require 'evm/command/list'
 require 'evm/command/bin'
 require 'evm/command/config'

--- a/lib/evm/command/disuse.rb
+++ b/lib/evm/command/disuse.rb
@@ -1,0 +1,15 @@
+module Evm
+  module Command
+    class Disuse
+      def initialize(argv, options = {})
+        package = Evm::Package.current
+
+        if package
+          package.disuse!
+        else
+          raise Evm::Exception.new('No package currently selected')
+        end
+      end
+    end
+  end
+end

--- a/lib/evm/package.rb
+++ b/lib/evm/package.rb
@@ -24,14 +24,25 @@ module Evm
     end
 
     def use!
+      delete_shims!
       [Evm::EMACS_PATH, Evm::EVM_EMACS_PATH].each do |bin_path|
-        @file.delete(bin_path) if @file.exists?(bin_path)
         @file.open(bin_path, 'w') do |file|
           file.puts("#!/bin/bash\nexec \"#{bin}\" \"$@\"")
         end
         @file.chmod(0755, bin_path)
       end
       Evm.config[:current] = name
+    end
+
+    def disuse!
+      delete_shims!
+      Evm.config[:current] = nil
+    end
+
+    def delete_shims!
+      [Evm::EMACS_PATH, Evm::EVM_EMACS_PATH].each do |bin_path|
+        @file.delete(bin_path) if @file.exists?(bin_path)
+      end
     end
 
     def install!
@@ -95,5 +106,7 @@ module Evm
         end
       end
     end
+
+    private :delete_shims!
   end
 end

--- a/spec/evm/command/disuse_spec.rb
+++ b/spec/evm/command/disuse_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Evm::Command::Disuse do
+  it 'should disuse package name if package selected' do
+    allow(Evm::Package).to receive(:current) do
+      package = double('package')
+      expect(package).to receive(:disuse!)
+      package
+    end
+
+    Evm::Command::Disuse.new([])
+  end
+
+  it 'should raise exception if no package selected' do
+    expect {
+      Evm::Command::Disuse.new([])
+    }.to raise_error('No package currently selected')
+  end
+end


### PR DESCRIPTION
After running `evm use` to run some tests for a project, I want to restore my normal Emacs version (managed by a separate package manager). Currently this means altering `PATH` back and forth or manually deleting the binary links. `evm disuse` will undo the settings made by `evm use` for you.