### PR TITLE
Add emacs-25.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ env:
   - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis
   - EVM_EMACS=emacs-25.2-travis
+  - EVM_EMACS=emacs-25.3-travis

--- a/recipes/emacs-25.3-travis.rb
+++ b/recipes/emacs-25.3-travis.rb
@@ -1,0 +1,7 @@
+recipe 'emacs-25.3-travis' do
+  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.11.0/emacs-25.3-travis.tar.gz'
+
+  install do
+    copy build_path, installations_path
+  end
+end

--- a/recipes/emacs-25.3.rb
+++ b/recipes/emacs-25.3.rb
@@ -1,0 +1,23 @@
+recipe 'emacs-25.3' do
+  tar_xz 'http://ftpmirror.gnu.org/emacs/emacs-25.3.tar.gz'
+
+  osx do
+    option '--with-ns'
+    option '--without-x'
+    option '--without-dbus'
+  end
+
+  linux do
+    option '--prefix', installation_path
+    option '--without-gif'
+  end
+
+  install do
+    configure
+    make 'install'
+
+    osx do
+      copy File.join(build_path, 'nextstep', 'Emacs.app'), installation_path
+    end
+  end
+end

--- a/recipes/emacs-git-snapshot-travis.rb
+++ b/recipes/emacs-git-snapshot-travis.rb
@@ -1,5 +1,5 @@
 recipe 'emacs-git-snapshot-travis' do
-  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.7.1/emacs-git-snapshot-travis.tar.gz'
+  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.11.0/emacs-git-snapshot-travis.tar.gz'
 
   install do
     copy build_path, installations_path


### PR DESCRIPTION
I'll edit the commit with the GitHub URL once you have made a release.

There is also a new git snapshot at
https://www.dropbox.com/s/twvkxrtav60rwny/emacs-git-snapshot-travis.tar.gz?dl=1
Note that this is really tip of master, so on the 27.x track. 26 has
already branched.