### PR TITLE
Assert that configured "path" is "/tmp" for Travis CI recipes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ before_install:
   - sudo apt-get build-dep -qq emacs23
   - sudo apt-get build-dep -qq emacs24
 
+  - bin/evm config path /tmp
   - bin/evm install $EVM_EMACS
   - bin/evm use $EVM_EMACS
 script:
   - bundle exec rspec spec
   - bin/emacs --version
+  - bin/emacs -Q --batch --eval '(unless (string= (getenv "EVM_EMACS") (format "emacs-%d.%d-travis" emacs-major-version emacs-minor-version)) (kill-emacs 1))'
 rvm:
   - 1.9.3
 env:

--- a/recipes/emacs-24.1-travis.rb
+++ b/recipes/emacs-24.1-travis.rb
@@ -1,6 +1,8 @@
 recipe 'emacs-24.1-travis' do
   tar_gz 'https://github.com/rejeep/evm/releases/download/v0.6.1/emacs-24.1-travis.tar.gz'
 
+  abort('config.path must be /tmp') unless Evm.config[:path] == '/tmp'
+
   install do
     copy build_path, installations_path
   end

--- a/recipes/emacs-24.2-travis.rb
+++ b/recipes/emacs-24.2-travis.rb
@@ -1,6 +1,8 @@
 recipe 'emacs-24.2-travis' do
   tar_gz 'https://github.com/rejeep/evm/releases/download/v0.6.1/emacs-24.2-travis.tar.gz'
 
+  abort('config.path must be /tmp') unless Evm.config[:path] == '/tmp'
+
   install do
     copy build_path, installations_path
   end

--- a/recipes/emacs-24.3-travis.rb
+++ b/recipes/emacs-24.3-travis.rb
@@ -1,6 +1,8 @@
 recipe 'emacs-24.3-travis' do
   tar_gz 'https://github.com/rejeep/evm/releases/download/v0.6.1/emacs-24.3-travis.tar.gz'
 
+  abort('config.path must be /tmp') unless Evm.config[:path] == '/tmp'
+
   install do
     copy build_path, installations_path
   end

--- a/recipes/emacs-24.4-travis.rb
+++ b/recipes/emacs-24.4-travis.rb
@@ -1,6 +1,8 @@
 recipe 'emacs-24.4-travis' do
   tar_gz 'https://github.com/rejeep/evm/releases/download/v0.6.1/emacs-24.4-travis.tar.gz'
 
+  abort('config.path must be /tmp') unless Evm.config[:path] == '/tmp'
+
   install do
     copy build_path, installations_path
   end

--- a/recipes/emacs-24.5-travis.rb
+++ b/recipes/emacs-24.5-travis.rb
@@ -1,6 +1,8 @@
 recipe 'emacs-24.5-travis' do
   tar_gz 'https://github.com/rejeep/evm/releases/download/v0.6.1/emacs-24.5-travis.tar.gz'
 
+  abort('config.path must be /tmp') unless Evm.config[:path] == '/tmp'
+
   install do
     copy build_path, installations_path
   end

--- a/recipes/emacs-25.1-travis.rb
+++ b/recipes/emacs-25.1-travis.rb
@@ -1,6 +1,8 @@
 recipe 'emacs-25.1-travis' do
   tar_gz 'https://github.com/rejeep/evm/releases/download/v0.9.0/emacs-25.1-travis.tar.gz'
 
+  abort('config.path must be /tmp') unless Evm.config[:path] == '/tmp'
+
   install do
     copy build_path, installations_path
   end

--- a/recipes/emacs-25.2-travis.rb
+++ b/recipes/emacs-25.2-travis.rb
@@ -1,6 +1,8 @@
 recipe 'emacs-25.2-travis' do
   tar_gz 'https://github.com/rejeep/evm/releases/download/v0.10.0/emacs-25.2-travis.tar.gz'
 
+  abort('config.path must be /tmp') unless Evm.config[:path] == '/tmp'
+
   install do
     copy build_path, installations_path
   end


### PR DESCRIPTION
Emacs recipes for Travis CI require "path" to be configured to "/tmp",
otherwise complaining for example with:

| Warning: arch-dependent data dir (/tmp/emacs-24.2-travis/libexec/emacs/24.2/x86_64-unknown-linux-gnu/) does not exist.
| Warning: arch-independent data dir (/tmp/emacs-24.2-travis/share/emacs/24.2/etc/) does not exist.
| Warning: Lisp directory `/tmp/emacs-24.2-travis/share/emacs/24.2/lisp' does not exist.
| Warning: Lisp directory `/tmp/emacs-24.2-travis/share/emacs/24.2/leim' does not exist.
| Error: charsets directory not found:
| /tmp/emacs-24.2-travis/share/emacs/24.2/etc/charsets
| Emacs will not function correctly without the character map files.
| Please check your installation!

This was not apparent in EVM's current Travis CI setup because the
code path is not triggered by "emacs --version".  In addition, the
current Travis CI setup did not actually test that the Emacs binary
running was the version requested by $EVM_EMACS, instead relying on
manual inspection of the test logs.

This change adds assertions that "path" is configured to "/tmp" for
the Emacs recipes that require so and that the running Emacs binary is
the version requested by $EVM_EMACS, with the latter also serving as a
rudimentary functional test.