### PR TITLE
Fix typo in git command

### DIFF
--- a/lib/evm/git.rb
+++ b/lib/evm/git.rb
@@ -8,7 +8,7 @@ module Evm
       File.exist?(@path)
     end
 
-    def clone(url, branch=nil)
+    def clone(url, branch = nil)
       args = 'clone', url, @path
       args << "--branch=#{branch}" if branch
       git(*args)

--- a/recipes/emacs-26-pretest.rb
+++ b/recipes/emacs-26-pretest.rb
@@ -1,5 +1,5 @@
 recipe 'emacs-26-pretest' do
-  git 'http://git.savannah.gnu.org/r/emacs.git --branch emacs-26.0.90'
+  git 'http://git.savannah.gnu.org/r/emacs.git', 'emacs-26.0.90'
 
   osx do
     option '--with-ns'


### PR DESCRIPTION
I don't think this mandates a v0.12.1 release but it's probably
clearer to make one anyway.