### PR TITLE
Remove spurious failure message

### DIFF
--- a/lib/evm/builder.rb
+++ b/lib/evm/builder.rb
@@ -86,7 +86,7 @@ module Evm
 
       private
 
-      def tar_packaged(url,extension)
+      def tar_packaged(url, extension)
         tar_file_path = File.join(builds_path, @name + '.tar.' + extension)
 
         remote_file = Evm::RemoteFile.new(url)

--- a/lib/evm/system.rb
+++ b/lib/evm/system.rb
@@ -7,7 +7,7 @@ module Evm
     def run(*args)
       succeeded = Kernel.system(@executable, *args)
       unless succeeded
-        print "Failed! See logs above for error."
+        STDOUT.puts "Failed! See logs above for error."
         Kernel.exit($?.exitstatus)
       end
     end

--- a/spec/evm/system_spec.rb
+++ b/spec/evm/system_spec.rb
@@ -25,6 +25,7 @@ describe Evm::System do
     end
 
     it 'should exit if the command fails' do
+      expect(STDOUT).to receive(:puts).with('Failed! See logs above for error.')
       expect(Kernel).to receive(:exit)
 
       # Based on http://stackoverflow.com/a/4589517


### PR DESCRIPTION
Test for the system command failure message rather than allowing it to
be confusingly printed in the test output.