### PR TITLE
Update emacs-26-pretest-travis without X11 support

### DIFF
--- a/recipes/emacs-26-pretest-travis.rb
+++ b/recipes/emacs-26-pretest-travis.rb
@@ -1,5 +1,5 @@
 recipe 'emacs-26-pretest-travis' do
-  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.12.0/emacs-26-pretest-travis.tar.gz'
+  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.13.0/emacs-26-pretest-travis.tar.gz'
 
   install do
     copy build_path, installations_path


### PR DESCRIPTION
This is aimed at being the exact same version as previously
released (to ensure we are only changing one thing at a time) but
without X11 support. Such support is not likely to be necessary for CI
testing, and enables use of the binaries in some other environments.