### PR TITLE
Update build recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ If you want to contribute a Travis binary, these instructions will help.
     ```bash
     docker$ cd emacs-$VERSION
     docker$ ./autogen.sh # for snapshot
-    docker$ ./configure --without-all --prefix=/tmp/emacs-$VERSION-travis
+    docker$ ./configure --with-x-toolkit=no --without-x --without-all --with-gnutls --prefix=/tmp/emacs-$VERSION-travis
     docker$ make bootstrap
     docker$ make install
     ```


### PR DESCRIPTION
* building with GnuTLS support becomes more important as support for
  deprecated, insecure methods is reduced further and further (and
  gnutls-bin is often not available by default).
* remove X11 support for a smaller, faster build that is more widely
  use-able (see #103).

Best to first see that this causes no problems, then merge, as it fixes #101. #102 can also be updated.