### PR TITLE
Make evm work when invoked through symlink

### DIFF
--- a/bin/evm
+++ b/bin/evm
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-$: << File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
+$: << File.join(File.dirname(File.dirname(File.realpath(__FILE__))), 'lib')
 
 require 'evm'
 


### PR DESCRIPTION
Previously if evm was invoked through a symlink instead of directly, `__FILE__`
pointed to the wrong file. It pointed to the symlink, not the actual evm script.
Thus the lib directory was wrong and 'require' failed.

This commit uses `__dir__` instead to resolve all possible symlinks. See this
Stackoverflow answer for more information:
https://stackoverflow.com/a/29494540/963029.

===========

Full disclosure: Up until now, I have never touched ruby. Thus, if this doesn't make sense at all, that might be the reason ^^