### PR TITLE
Readability of or versus path

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ export PATH="$HOME/.evm/bin:$PATH"
 In the Evm `bin` directory, there are a few commands:
 
 * `evm` - Manage Emacs packages
-* `emacs/evm-emacs` - Emacs shim with currently selected Emacs package
+* `emacs`/`evm-emacs` - Emacs shim with currently selected Emacs package
 
 ### list
 


### PR DESCRIPTION
I had to stare at it for a moment to realize it was not a directory `emacs` and path to `evm-emacs`, but rather alternatively `emacs` or `evm-emacs`. Or would it be clearer to say "`emacs` or `evm-emacs`"?