### PR TITLE
Temporarily enforce trusty in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: linux
+dist: trusty
 language: ruby
 before_install:
   - sudo mkdir /usr/local/evm


### PR DESCRIPTION
In future we will probably build for and test multiple operating
systems/distributions but for now we need to fix the build.