### PR TITLE
Add Xenial support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,9 +89,3 @@ script:
                      (and (string= (getenv "EVM_EMACS") "emacs-git-snapshot-travis")
                           (= emacs-major-version 27)))
                  (kill-emacs 1))'
-rvm:
-  - 2.3.8
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
-  - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,75 @@
-os: linux
-dist: trusty
 language: ruby
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      env: EVM_EMACS=emacs-24.1-travis
+    - os: linux
+      dist: trusty
+      env: EVM_EMACS=emacs-24.2-travis
+    - os: linux
+      dist: trusty
+      env: EVM_EMACS=emacs-24.3-travis
+    - os: linux
+      dist: trusty
+      env: EVM_EMACS=emacs-24.4-travis
+    - os: linux
+      dist: trusty
+      env: EVM_EMACS=emacs-24.5-travis
+    - os: linux
+      dist: trusty
+      env: EVM_EMACS=emacs-25.1-travis
+    - os: linux
+      dist: trusty
+      env: EVM_EMACS=emacs-25.2-travis
+    - os: linux
+      dist: trusty
+      env: EVM_EMACS=emacs-25.3-travis
+    - os: linux
+      dist: trusty
+      env: EVM_EMACS=emacs-26.1-travis
+    - os: linux
+      dist: trusty
+      env: EVM_EMACS=emacs-26.2-travis
+    - os: linux
+      dist: trusty
+      env: EVM_EMACS=emacs-26.3-travis
+    - os: linux
+      dist: trusty
+      env: EVM_EMACS=emacs-git-snapshot-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-24.1-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-24.2-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-24.3-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-24.4-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-24.5-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-25.1-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-25.2-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-25.3-travis
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-26.1-travis-linux-xenial
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-26.2-travis-linux-xenial
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-26.3-travis-linux-xenial
 before_install:
   - sudo mkdir /usr/local/evm
   - sudo chown travis:travis /usr/local/evm
@@ -13,10 +82,10 @@ script:
   - bundle exec rspec spec
   - bin/emacs --version
   - bin/emacs -Q --batch --eval
-        '(unless (or (string= (getenv "EVM_EMACS")
-                              (format "emacs-%d.%d-travis"
-                                      emacs-major-version
-                                      emacs-minor-version))
+        '(unless (or (string-prefix-p (format "emacs-%d.%d-travis"
+                                              emacs-major-version
+                                              emacs-minor-version)
+                                      (getenv "EVM_EMACS"))
                      (and (string= (getenv "EVM_EMACS") "emacs-git-snapshot-travis")
                           (= emacs-major-version 27)))
                  (kill-emacs 1))'
@@ -26,16 +95,3 @@ rvm:
   - 2.5.5
   - 2.6.3
   - ruby-head
-env:
-  - EVM_EMACS=emacs-24.1-travis
-  - EVM_EMACS=emacs-24.2-travis
-  - EVM_EMACS=emacs-24.3-travis
-  - EVM_EMACS=emacs-24.4-travis
-  - EVM_EMACS=emacs-24.5-travis
-  - EVM_EMACS=emacs-25.1-travis
-  - EVM_EMACS=emacs-25.2-travis
-  - EVM_EMACS=emacs-25.3-travis
-  - EVM_EMACS=emacs-26.1-travis
-  - EVM_EMACS=emacs-26.2-travis
-  - EVM_EMACS=emacs-26.3-travis
-  - EVM_EMACS=emacs-git-snapshot-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ before_install:
   - sudo mkdir /usr/local/evm
   - sudo chown travis:travis /usr/local/evm
 
-  - sudo add-apt-repository -y ppa:cassou/emacs
-  - sudo apt-get update -qq
-  - sudo apt-get build-dep -qq emacs23
-  - sudo apt-get build-dep -qq emacs24
-
   - bin/evm config path /tmp
   - bin/evm install $EVM_EMACS
   - bin/evm use $EVM_EMACS

--- a/docker/build-emacs.sh
+++ b/docker/build-emacs.sh
@@ -18,10 +18,10 @@ function build_emacs() {
                     --without-x \
                     --without-all \
                     --with-gnutls \
-                    --prefix="/tmp/emacs-${VERSION}-travis" && \
+                    --prefix="/tmp/${RELEASE}" && \
         make bootstrap && \
         make install && \
-        tar -C /tmp -czf "/tmp/emacs-${VERSION}-travis.tar.gz" "emacs-${VERSION}-travis"
+        tar -C /tmp -czf "/tmp/${RELEASE}.tar.gz" "${RELEASE}"
 }
 
 build_emacs

--- a/docker/linux-trusty.Dockerfile
+++ b/docker/linux-trusty.Dockerfile
@@ -1,0 +1,20 @@
+FROM travisci/ci-garnet:packer-1515445631-7dfb2e1
+
+# hadolint ignore=DL3008
+RUN apt-get update -y \
+    && apt-get install --no-install-recommends -y \
+        autoconf \
+        autogen \
+        automake \
+        build-essential \
+        git \
+        libncurses-dev \
+        libtool \
+        texinfo \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+USER travis
+WORKDIR /home/travis
+COPY build-emacs.sh /home/travis/
+CMD ["./build-emacs.sh"]

--- a/docker/linux-xenial.Dockerfile
+++ b/docker/linux-xenial.Dockerfile
@@ -1,4 +1,4 @@
-FROM travisci/ci-garnet:packer-1515445631-7dfb2e1
+FROM travisci/ci-sardonyx:packer-1564753982-0c06deb6
 
 # hadolint ignore=DL3008
 RUN apt-get update -y \
@@ -8,6 +8,7 @@ RUN apt-get update -y \
         automake \
         build-essential \
         git \
+        libgnutls-dev \
         libncurses-dev \
         libtool \
         texinfo \
@@ -16,5 +17,5 @@ RUN apt-get update -y \
 
 USER travis
 WORKDIR /home/travis
-COPY docker/build-emacs.sh /home/travis/
+COPY build-emacs.sh /home/travis/
 CMD ["./build-emacs.sh"]

--- a/recipes/emacs-26.1-travis-linux-xenial.rb
+++ b/recipes/emacs-26.1-travis-linux-xenial.rb
@@ -1,5 +1,5 @@
 recipe 'emacs-26.1-travis-linux-xenial' do
-  tar_gz 'https://www.dropbox.com/s/w8skjn8dts24be6/emacs-26.1-travis-linux-xenial.tar.gz?dl=1'
+  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.18.0/emacs-26.1-travis.tar.gz'
 
   install do
     copy build_path, installations_path

--- a/recipes/emacs-26.1-travis-linux-xenial.rb
+++ b/recipes/emacs-26.1-travis-linux-xenial.rb
@@ -1,0 +1,7 @@
+recipe 'emacs-26.1-travis-linux-xenial' do
+  tar_gz 'https://www.dropbox.com/s/w8skjn8dts24be6/emacs-26.1-travis-linux-xenial.tar.gz?dl=1'
+
+  install do
+    copy build_path, installations_path
+  end
+end

--- a/recipes/emacs-26.2-travis-linux-xenial.rb
+++ b/recipes/emacs-26.2-travis-linux-xenial.rb
@@ -1,0 +1,7 @@
+recipe 'emacs-26.2-travis-linux-xenial' do
+  tar_gz 'https://www.dropbox.com/s/vk3lhjy82462zlh/emacs-26.2-travis-linux-xenial.tar.gz?dl=1'
+
+  install do
+    copy build_path, installations_path
+  end
+end

--- a/recipes/emacs-26.2-travis-linux-xenial.rb
+++ b/recipes/emacs-26.2-travis-linux-xenial.rb
@@ -1,5 +1,5 @@
 recipe 'emacs-26.2-travis-linux-xenial' do
-  tar_gz 'https://www.dropbox.com/s/vk3lhjy82462zlh/emacs-26.2-travis-linux-xenial.tar.gz?dl=1'
+  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.18.0/emacs-26.2-travis.tar.gz'
 
   install do
     copy build_path, installations_path

--- a/recipes/emacs-26.3-travis-linux-xenial.rb
+++ b/recipes/emacs-26.3-travis-linux-xenial.rb
@@ -1,0 +1,7 @@
+recipe 'emacs-26.3-travis-linux-xenial' do
+  tar_gz 'https://www.dropbox.com/s/xd28wgjtlfvgrlj/emacs-26.3-travis-linux-xenial.tar.gz?dl=1'
+
+  install do
+    copy build_path, installations_path
+  end
+end

--- a/recipes/emacs-26.3-travis-linux-xenial.rb
+++ b/recipes/emacs-26.3-travis-linux-xenial.rb
@@ -1,5 +1,5 @@
 recipe 'emacs-26.3-travis-linux-xenial' do
-  tar_gz 'https://www.dropbox.com/s/xd28wgjtlfvgrlj/emacs-26.3-travis-linux-xenial.tar.gz?dl=1'
+  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.18.0/emacs-26.3-travis.tar.gz'
 
   install do
     copy build_path, installations_path


### PR DESCRIPTION
Per #125, it currently seems to make sense to just release new
binaries for different OS/distribution combinations. Preferably
aliases of some sort will be added in future so that people can depend
on a version suitable for the current Travis default without having to
change their configuration. It would also allow a single binary to
serve multiple OS/distribution combinations where that is possible,
whilst maintaining consistency in naming.

Fixes #125.