### PR TITLE
Add new Git snapshot versions, including Xenial compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
       env: EVM_EMACS=emacs-26.3-travis
     - os: linux
       dist: trusty
-      env: EVM_EMACS=emacs-git-snapshot-travis
+      env: EVM_EMACS=emacs-git-snapshot-travis-linux-trusty
     - os: linux
       dist: xenial
       env: EVM_EMACS=emacs-24.1-travis
@@ -70,6 +70,9 @@ matrix:
     - os: linux
       dist: xenial
       env: EVM_EMACS=emacs-26.3-travis-linux-xenial
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-git-snapshot-travis-linux-xenial
 before_install:
   - sudo mkdir /usr/local/evm
   - sudo chown travis:travis /usr/local/evm
@@ -86,6 +89,6 @@ script:
                                               emacs-major-version
                                               emacs-minor-version)
                                       (getenv "EVM_EMACS"))
-                     (and (string= (getenv "EVM_EMACS") "emacs-git-snapshot-travis")
+                     (and (string-prefix-p "emacs-git-snapshot-travis" (getenv "EVM_EMACS"))
                           (= emacs-major-version 27)))
                  (kill-emacs 1))'

--- a/recipes/emacs-git-snapshot-travis-linux-trusty.rb
+++ b/recipes/emacs-git-snapshot-travis-linux-trusty.rb
@@ -1,0 +1,7 @@
+recipe 'emacs-git-snapshot-travis-linux-trusty' do
+  tar_gz 'https://www.dropbox.com/s/b1jmlm8d8ubxi52/emacs-git-snapshot-travis-linux-trusty.tar.gz?dl=1'
+
+  install do
+    copy build_path, installations_path
+  end
+end

--- a/recipes/emacs-git-snapshot-travis-linux-trusty.rb
+++ b/recipes/emacs-git-snapshot-travis-linux-trusty.rb
@@ -1,5 +1,5 @@
 recipe 'emacs-git-snapshot-travis-linux-trusty' do
-  tar_gz 'https://www.dropbox.com/s/b1jmlm8d8ubxi52/emacs-git-snapshot-travis-linux-trusty.tar.gz?dl=1'
+  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.19.0/emacs-git-snapshot-travis-linux-trusty.tar.gz'
 
   install do
     copy build_path, installations_path

--- a/recipes/emacs-git-snapshot-travis-linux-xenial.rb
+++ b/recipes/emacs-git-snapshot-travis-linux-xenial.rb
@@ -1,5 +1,5 @@
 recipe 'emacs-git-snapshot-travis-linux-xenial' do
-  tar_gz 'https://www.dropbox.com/s/j4t3tp1uxz0rjc9/emacs-git-snapshot-travis-linux-xenial.tar.gz?dl=1'
+  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.19.0/emacs-git-snapshot-travis-linux-xenial.tar.gz'
 
   install do
     copy build_path, installations_path

--- a/recipes/emacs-git-snapshot-travis-linux-xenial.rb
+++ b/recipes/emacs-git-snapshot-travis-linux-xenial.rb
@@ -1,0 +1,7 @@
+recipe 'emacs-git-snapshot-travis-linux-xenial' do
+  tar_gz 'https://www.dropbox.com/s/j4t3tp1uxz0rjc9/emacs-git-snapshot-travis-linux-xenial.tar.gz?dl=1'
+
+  install do
+    copy build_path, installations_path
+  end
+end


### PR DESCRIPTION
* both use full names
* emacs-git-snapshot trusty may later point to one of these
* trusty/xenial versions may not be exactly the same commit