### PR TITLE
Add Emacs 27.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ matrix:
       env: EVM_EMACS=emacs-26.3-travis
     - os: linux
       dist: trusty
+      env: EVM_EMACS=emacs-27.1-travis-linux-trusty
+    - os: linux
+      dist: trusty
       env: EVM_EMACS=emacs-git-snapshot-travis-linux-trusty
     - os: linux
       dist: xenial
@@ -70,6 +73,9 @@ matrix:
     - os: linux
       dist: xenial
       env: EVM_EMACS=emacs-26.3-travis-linux-xenial
+    - os: linux
+      dist: xenial
+      env: EVM_EMACS=emacs-27.1-travis-linux-xenial
     - os: linux
       dist: xenial
       env: EVM_EMACS=emacs-git-snapshot-travis-linux-xenial

--- a/recipes/emacs-27.1-travis-linux-trusty.rb
+++ b/recipes/emacs-27.1-travis-linux-trusty.rb
@@ -1,0 +1,7 @@
+recipe 'emacs-27.1-travis-linux-trusty' do
+  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.21.0/emacs-27.1-travis-linux-trusty.tar.gz'
+
+  install do
+    copy build_path, installations_path
+  end
+end

--- a/recipes/emacs-27.1-travis-linux-trusty.rb
+++ b/recipes/emacs-27.1-travis-linux-trusty.rb
@@ -1,5 +1,5 @@
 recipe 'emacs-27.1-travis-linux-trusty' do
-  tar_gz 'https://www.dropbox.com/s/0g9bwt0vywrvl18/emacs-27.1-travis-linux-trusty.tar.gz?dl=1'
+  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.21.0/emacs-27.1-travis-linux-trusty.tar.gz'
 
   install do
     copy build_path, installations_path

--- a/recipes/emacs-27.1-travis-linux-trusty.rb
+++ b/recipes/emacs-27.1-travis-linux-trusty.rb
@@ -1,5 +1,5 @@
 recipe 'emacs-27.1-travis-linux-trusty' do
-  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.21.0/emacs-27.1-travis-linux-trusty.tar.gz'
+  tar_gz 'https://www.dropbox.com/s/0g9bwt0vywrvl18/emacs-27.1-travis-linux-trusty.tar.gz?dl=1'
 
   install do
     copy build_path, installations_path

--- a/recipes/emacs-27.1-travis-linux-xenial.rb
+++ b/recipes/emacs-27.1-travis-linux-xenial.rb
@@ -1,0 +1,7 @@
+recipe 'emacs-27.1-travis-linux-xenial' do
+  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.21.0/emacs-27.1-travis-linux-xenial.tar.gz'
+
+  install do
+    copy build_path, installations_path
+  end
+end

--- a/recipes/emacs-27.1-travis-linux-xenial.rb
+++ b/recipes/emacs-27.1-travis-linux-xenial.rb
@@ -1,5 +1,5 @@
 recipe 'emacs-27.1-travis-linux-xenial' do
-  tar_gz 'https://www.dropbox.com/s/57k8ijryc3lw7vv/emacs-27.1-travis-linux-xenial.tar.gz?dl=1'
+  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.21.0/emacs-27.1-travis-linux-xenial.tar.gz'
 
   install do
     copy build_path, installations_path

--- a/recipes/emacs-27.1-travis-linux-xenial.rb
+++ b/recipes/emacs-27.1-travis-linux-xenial.rb
@@ -1,5 +1,5 @@
 recipe 'emacs-27.1-travis-linux-xenial' do
-  tar_gz 'https://github.com/rejeep/evm/releases/download/v0.21.0/emacs-27.1-travis-linux-xenial.tar.gz'
+  tar_gz 'https://www.dropbox.com/s/57k8ijryc3lw7vv/emacs-27.1-travis-linux-xenial.tar.gz?dl=1'
 
   install do
     copy build_path, installations_path

--- a/recipes/emacs-27.1.rb
+++ b/recipes/emacs-27.1.rb
@@ -1,0 +1,23 @@
+recipe 'emacs-27.1' do
+  tar_gz 'http://ftpmirror.gnu.org/emacs/emacs-27.1.tar.gz'
+
+  osx do
+    option '--with-ns'
+    option '--without-x'
+    option '--without-dbus'
+  end
+
+  linux do
+    option '--prefix', installation_path
+    option '--without-gif'
+  end
+
+  install do
+    configure
+    make 'install'
+
+    osx do
+      copy File.join(build_path, 'nextstep', 'Emacs.app'), installation_path
+    end
+  end
+end


### PR DESCRIPTION
Explicit Trust/Xenial naming, no distribution-less named default for now.